### PR TITLE
Add anchor earn deposit support. 

### DIFF
--- a/anchorprotocol.py
+++ b/anchorprotocol.py
@@ -123,9 +123,10 @@ def keep_loan_safe(anchor_hodl, current_ltv):
                     broadcast_result = anchor_hodl.terra.tx.broadcast(execute_deposit)
                     time.sleep(2)
                     if broadcast_result.txhash:
-                       deposit_log = f"Deposited! Total Amount: ${deposit_amount:,.2f}, "
+                       deposit_log = f"Deposited! Total Amount: ${deposit_amount:,.2f}, "\
+                                     f"TX: {anchor_hodl.tx_look_up}{broadcast_result.txhash}"
                 else:
-                    deposit_log = "Not enough to deposit"
+                    deposit_log = "Deposit Skipped! Not enough borrowed to deposit."
 
                 logger.info(deposit_log)
             return True

--- a/anchorprotocol.py
+++ b/anchorprotocol.py
@@ -108,18 +108,22 @@ def keep_loan_safe(anchor_hodl, current_ltv):
                     current_ltv['loan_amount'])
                 execute_borrow = anchor_execute_borrow_ust(anchor_hodl, borrow_amount)
                 broadcast_result = anchor_hodl.terra.tx.broadcast(execute_borrow)
-                borrow_log = f"Borrowed! Total Amount: ${borrow_amount:,.2f}, " \
-                             f"triggered at: {current_ltv['left_to_trigger']} " \
-                             f"({config.trigger_at_percent}% trigger limit). " \
-                             f"TX: {anchor_hodl.tx_look_up}{broadcast_result.txhash}"
-                logger.info(borrow_log)
+                time.sleep(2)
+                if broadcast_result.txhash:
+                    borrow_log = f"Borrowed! Total Amount: ${borrow_amount:,.2f}, " \
+                                f"triggered at: {current_ltv['left_to_trigger']} " \
+                                f"({config.trigger_at_percent}% trigger limit). " \
+                                f"TX: {anchor_hodl.tx_look_up}{broadcast_result.txhash}"
+                    logger.info(borrow_log)
 
                 # Depsoit ust into anchor earn after borrowing
                 deposit_amount = borrow_amount - 10 # always increase + 10 to cover fees
                 if deposit_amount > 0:
                     execute_deposit = anchor_execute_deposit_earn(anchor_hodl, deposit_amount)
                     broadcast_result = anchor_hodl.terra.tx.broadcast(execute_deposit)
-                    deposit_log = f"Deposited! Total Amount: ${deposit_amount:,.2f}, "
+                    time.sleep(2)
+                    if broadcast_result.txhash:
+                       deposit_log = f"Deposited! Total Amount: ${deposit_amount:,.2f}, "
                 else:
                     deposit_log = "Not enough to deposit"
 

--- a/anchorprotocol.py
+++ b/anchorprotocol.py
@@ -116,11 +116,14 @@ def keep_loan_safe(anchor_hodl, current_ltv):
 
                 # Depsoit ust into anchor earn after borrowing
                 deposit_amount = borrow_amount - 10 # always increase + 10 to cover fees
-                execute_deposit = anchor_execute_deposit_earn(anchor_hodl, deposit_amount)
-                broadcast_result = anchor_hodl.terra.tx.broadcast(execute_deposit)
-                deposit_log = f"Deposited! Total Amount: ${deposit_amount:,.2f}, "
-                logger.info(deposit_log)
+                if deposit_amount > 0:
+                    execute_deposit = anchor_execute_deposit_earn(anchor_hodl, deposit_amount)
+                    broadcast_result = anchor_hodl.terra.tx.broadcast(execute_deposit)
+                    deposit_log = f"Deposited! Total Amount: ${deposit_amount:,.2f}, "
+                else:
+                    deposit_log = "Not enough to deposit"
 
+                logger.info(deposit_log)
             return True
 
     except Exception as err:

--- a/anchorprotocol.py
+++ b/anchorprotocol.py
@@ -287,7 +287,7 @@ def anchor_execute_deposit_earn(anchor_hodl, amount):
     contract_address = anchor_hodl.mmMarket
     msg = {"deposit_stable": {}}
 
-    tx_return = anchor_hodl.contract_executor(anchor_hodl, contract_address, msg, coins)
+    tx_return = contract_executor(anchor_hodl, contract_address, msg, coins)
 
     return tx_return
 

--- a/anchorprotocol.py
+++ b/anchorprotocol.py
@@ -114,6 +114,13 @@ def keep_loan_safe(anchor_hodl, current_ltv):
                              f"TX: {anchor_hodl.tx_look_up}{broadcast_result.txhash}"
                 logger.info(borrow_log)
 
+                # Depsoit ust into anchor earn after borrowing
+                deposit_amount = borrow_amount - 10 # always increase + 10 to cover fees
+                execute_deposit = anchor_execute_deposit_earn(anchor_hodl, deposit_amount)
+                broadcast_result = anchor_hodl.terra.tx.broadcast(execute_deposit)
+                deposit_log = f"Deposited! Total Amount: ${deposit_amount:,.2f}, "
+                logger.info(deposit_log)
+
             return True
 
     except Exception as err:
@@ -271,6 +278,18 @@ def anchor_execute_borrow_ust(anchor_hodl, amount):
 
     return anchor_execute_loan_repay_tx
 
+def anchor_execute_deposit_earn(anchor_hodl, amount):
+    # Deposit UST into anchor earn
+    amount = int(amount * 1000000)
+    coin = Coin("uusd", amount).to_data()
+    coins = Coins.from_data([coin])
+
+    contract_address = anchor_hodl.mmMarket
+    msg = {"deposit_stable": {}}
+
+    tx_return = anchor_hodl.contract_executor(anchor_hodl, contract_address, msg, coins)
+
+    return tx_return
 
 def contract_executor(anchor_hodl, contract_addr, execute_msg, send_coins):
     # sequence = anchor_hodl.wallet.sequence()


### PR DESCRIPTION
Heres what the output looks like
```
10-12-2021 12:25:53 [INFO] Deposited! Total Amount: $128.00, TX: https://finder.terra.money/bombay-12/tx/E79B569A99FE52CDA2210E822D98FF96F09F7EF51B53FF2FAEB3304FD2A0A3EF
10-12-2021 12:25:47 [INFO] Borrowed! Total Amount: $138.00, triggered at: 81.45 (90% trigger limit). TX: https://finder.terra.money/bombay-12/tx/D3505C3996B0012BF0F723D06D73D9F732BDC18CB656E84052D5BC5478AE855E
```

This will deposit the borrowed amount - 10 UST to guarantee there is some money in the wallet. Over time this will probably accumulate but it will allow users keep UST in their wallet without worrying about all of it going into anchor earn in case they are going to use it for something.